### PR TITLE
(Last 1) Allow selection of fourth option in Poll

### DIFF
--- a/src/components/Poll.js
+++ b/src/components/Poll.js
@@ -74,11 +74,11 @@ function mapStateToProps ({ authedUser, polls, users}, { match }) {
 
   const vote = getVoteKeys().reduce((vote, key) => {
     if (vote !== null) {
-      return vote[0]
+      return vote
     }
 
     return poll[key].includes(authedUser)
-      ? key
+      ? key[0]
       : vote
   }, null)
 


### PR DESCRIPTION
When the fourth option is selected the whole string is passed to props instead of just the first character. This is because the first character was only being returned on the next iteration of the reduce function. By returning key[0], the selection of the first character occurs when we initially capture the vote of the user, and doesn't require an additional iteration.